### PR TITLE
Fix input arguments for `gray` pixel format video

### DIFF
--- a/file_formats/behavior_videos.md
+++ b/file_formats/behavior_videos.md
@@ -61,7 +61,7 @@ Since this format will depend on the scientific question and software/hardware c
   `gray`. For color videos, the input arguments might need to be altered to
   match the color space of the input.
   
-  - output arguments: `-vf "scale=out_color_matrix=bt709:out_range=full" -c:v h264_nvenc -pix_fmt nv12 -color_range full -colorspace bt709 -color_trc linear -tune hq -preset p4 -rc vbr -cq 12 -b:v 0M -metadata author="Allen Institute for Neural Dynamics" -maxrate 700M -bufsize 350M`
+  - output arguments: `-vf "scale=out_color_matrix=bt709:out_range=full,format=bgr24,scale=out_range=full" -c:v h264_nvenc -pix_fmt yuv420p -color_range full -colorspace bt709 -color_trc linear -tune hq -preset p4 -rc vbr -cq 12 -b:v 0M -metadata author="Allen Institute for Neural Dynamics" -maxrate 700M -bufsize 350M`
   - input_arguments: `-colorspace bt709 -color_primaries bt709 -color_range full -color_trc linear`
 
 
@@ -69,6 +69,9 @@ and the following encoding codec string for offline re-encoding (optimized for q
 
 - output arguments: `vf "scale=out_color_matrix=bt709:out_range=full:sws_dither=none,format=yuv420p10le,colorspace=ispace=bt709:all=bt709:dither=none,scale=out_range=tv:sws_dither=none,format=yuv420p" -c:v libx264 -preset veryslow -crf 18 -pix_fmt yuv420p -metadata author="Allen Institute for Neural Dynamics" -movflags +faststart+write_colr`
 
+For higher bitdepth (more than eight) recordings, change the output arguments of the online encoding to be as follows:
+  - output arguments: `-vf "scale=out_color_matrix=bt709:out_range=full,format=rgb48le,scale=out_range=full" -c:v h264_nvenc -pix_fmt yuv420p -color_range full -colorspace bt709 -color_trc linear -tune hq -preset p4 -rc vbr -cq 12 -b:v 0M -metadata author="Allen Institute for Neural Dynamics" -maxrate 700M -bufsize 350M`
+This is almost the same, except the intermediate color representation is 48 bits per pixel instead of 24.
 ### Application notes
 
 We currently support the following cameras:

--- a/file_formats/behavior_videos.md
+++ b/file_formats/behavior_videos.md
@@ -57,8 +57,13 @@ Since this format will depend on the scientific question and software/hardware c
 - Acquire without any gamma correction
 - Use `ffmpeg` with the following encoding codec string for online encoding (optimized for compression quality and speed):
 
+  Note: this has been tested with monochrome videos with the raw pixel format
+  `gray`. For color videos, the input arguments might need to be altered to
+  match the color space of the input.
+  
   - output arguments: `-vf "scale=out_color_matrix=bt709:out_range=full" -c:v h264_nvenc -pix_fmt nv12 -color_range full -colorspace bt709 -color_trc linear -tune hq -preset p4 -rc vbr -cq 12 -b:v 0M -metadata author="Allen Institute for Neural Dynamics" -maxrate 700M -bufsize 350M`
-  - input_arguments: `-colorspace rgb -color_primaries bt709 -color_trc linear`
+  - input_arguments: `-colorspace bt709 -color_primaries bt709 -color_range full -color_trc linear`
+
 
 and the following encoding codec string for offline re-encoding (optimized for quality and size):
 

--- a/file_formats/behavior_videos.md
+++ b/file_formats/behavior_videos.md
@@ -67,7 +67,7 @@ Since this format will depend on the scientific question and software/hardware c
 
 and the following encoding codec string for offline re-encoding (optimized for quality and size):
 
-- output arguments: `-vf "scale=out_color_matrix=bt709:out_range=full:sws_dither=none,colorspace=ispace=bt709:all=bt709:dither=none,scale=out_range=tv:sws_dither=none,format=yuv420p" -c:v libx264 -preset veryslow -crf 18 -pix_fmt yuv420p -metadata author="Allen Institute for Neural Dynamics" -movflags +faststart+write_colr`
+- output arguments: `vf "scale=out_color_matrix=bt709:out_range=full:sws_dither=none,format=yuv420p10le,colorspace=ispace=bt709:all=bt709:dither=none,scale=out_range=tv:sws_dither=none,format=yuv420p" -c:v libx264 -preset veryslow -crf 18 -pix_fmt yuv420p -metadata author="Allen Institute for Neural Dynamics" -movflags +faststart+write_colr`
 
 ### Application notes
 

--- a/file_formats/behavior_videos.md
+++ b/file_formats/behavior_videos.md
@@ -67,7 +67,7 @@ Since this format will depend on the scientific question and software/hardware c
 
 and the following encoding codec string for offline re-encoding (optimized for quality and size):
 
-- output arguments: `vf "scale=out_color_matrix=bt709:out_range=full:sws_dither=none,format=yuv420p10le,colorspace=ispace=bt709:all=bt709:dither=none,scale=out_range=tv:sws_dither=none,format=yuv420p" -c:v libx264 -preset veryslow -crf 18 -pix_fmt yuv420p -metadata author="Allen Institute for Neural Dynamics" -movflags +faststart+write_colr`
+- output arguments: `-vf "scale=out_color_matrix=bt709:out_range=full:sws_dither=none,format=yuv420p10le,colorspace=ispace=bt709:all=bt709:dither=none,scale=out_range=tv:sws_dither=none,format=yuv420p" -c:v libx264 -preset veryslow -crf 18 -pix_fmt yuv420p -metadata author="Allen Institute for Neural Dynamics" -movflags +faststart+write_colr`
 
 For higher bitdepth (more than eight) recordings, change the output arguments of the online encoding to be as follows:
   - output arguments: `-vf "scale=out_color_matrix=bt709:out_range=full,format=rgb48le,scale=out_range=full" -c:v h264_nvenc -pix_fmt yuv420p -color_range full -colorspace bt709 -color_trc linear -tune hq -preset p4 -rc vbr -cq 12 -b:v 0M -metadata author="Allen Institute for Neural Dynamics" -maxrate 700M -bufsize 350M`


### PR DESCRIPTION
The original suggested ffmpeg encoding had various problems with the colorspace when using `gray` raw pixel formats, instead of the `bgr24` that I developed them with. Since most users will have pixel data in the raw  `gray` format, these changes are necessary to allow the first-stage encoding to work as intended for most users.

Also fixed another unintentional omission in the second-stage encoding.