### PR TITLE
Align issue/pr templates with merged core standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,28 +1,31 @@
 ---
-name: Create a new specification
-about: For proposals that have been invited by a team member
-title: 'Feature name'
+name: Issues and feature requests for current standards
+title: 'Describe the issue or feature request'
 labels: proposal
 assignees: ''
 
 ---
 
-**Summary**
-General description of the change, should also list the affected standard(s)
+## Summary
 
-**Motivation**
-Why is the change necessary?
+- General description of the change, should also list the affected standard(s)
 
-**Detailed Design**
-Proposed change, if applicable
+## Motivation
 
-**Drawbacks / Potential impact**
-What can go wrong? Will it affect an existing standard?
+- Why is the change necessary? What improvements does it provide?
 
-**Alternatives**
+## Detailed Design
 
-**Unresolved Questions**
+- Proposed change, if applicable.
 
-**Stakeholders**
-Who should be involved in the discussion/potentially affected by the chance?
+## Drawbacks / Potential impact
 
+- What can go wrong? Will it affect an existing standard?
+
+## Alternatives
+
+## Unresolved Questions
+
+## Stakeholders
+
+- Who should be involved in the discussion/potentially affected by the chance?

--- a/.github/PULL_REQUEST_TEMPLATE/feature_proposal.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature_proposal.md
@@ -1,0 +1,23 @@
+---
+name: Technical proposal for new or modified standard
+title: 'Concise title of the proposal'
+labels: proposal
+assignees: ''
+
+---
+
+## Summary
+
+- General description of the change, should also list the affected standard(s)
+
+## Motivation
+
+- Why is the change necessary? What improvements does it provide?
+
+## Detailed Design
+
+- Detailed description of the proposed change.
+
+## Relevant Issues
+
+- List all issues that are linked to this proposal.


### PR DESCRIPTION
This PRs aligns the language between the documentation that has been merged to main and the templates used for issues (feature requests / issues) and PRs (for concrete proposals). It also reformats the template to use proper headers for titles to make it easier to parse the document online.