### PR TITLE
Add optogenetic indicator benchmarking.md

### DIFF
--- a/file_formats/OptogeneticIndicatorBenchmarking.md
+++ b/file_formats/OptogeneticIndicatorBenchmarking.md
@@ -14,7 +14,7 @@ In older dataset, individual files are all stored directly under each session fo
 ### File format 
 In most cases, FIP data will be saved in `CSV` files, where each file corresponds to a different channel in the photometry rig. In addition to the timeseries fluorescence data, files containing metadata and raw image data are also available. A single session of FIP data should be organized under the `fib` directory. An acquisition for a single session should be nested under a sub directory named following the core standards for file naming convention found [here](https://github.com/AllenNeuralDynamics/aind-file-standards/blob/main/core/core-standards.md#filename-conventions).  Mostly, this is for cases where the recording gets interrupted. When the system restarts under the same session, it can be added to a new folder. A sessions folder structure should look like the following:
 
-## Old 
+### Old 
 ```plaintext
 📦 Session Folder
 ┣ Signal_YYYY-MM-DDTHH_MM_SS.csv
@@ -24,10 +24,16 @@ In most cases, FIP data will be saved in `CSV` files, where each file correspond
 ┣ Raw_Iso_YYYY-MM-DDTHH_MM_SS.bin
 ┣ Raw_Stim_YYYY-MM-DDTHH_MM_SS.bin
 ┣ TS_FLIR_YYYY-MM-DDTHH_MM_SS.csv
-┗ FIP_ROI_YYYY-MM-DDTHH_MM_SS.csv
+┣ FIP_ROI_YYYY-MM-DDTHH_MM_SS.csv
+┣ ***Camera_YYYY-MM-DDTHH_MM_SS.avi
+┣ ***Camera_YYYY-MM-DDTHH_MM_SS.csv
+┣
 ```
+`Signal` `Iso` `Stim` csv files in this old dataset do not have headers. Each column corresponds to the following:
+`SoftwareTS`,`ROI0`,`ROI1`,`ROI3`, and `ROI4_sensorfloor`
 
-## New 
+
+### New 2025-
 ```plaintext
 📦 Session Folder
 ┣ 📂 <fib>
@@ -42,8 +48,26 @@ In most cases, FIP data will be saved in `CSV` files, where each file correspond
 ┃
 ┣ 📂 <behavior>
 ```
+`Signal` `Iso` `Stim` csv files have the following headers for columnsd in the following order:
 
-A HARP Device (behavior board) is only used to trigger behavior cameras. Given the fip acquision and optogenetic stimulations are temporally precisely controlled together by the Teeny microcontroller, we will use software(OS) timestamps for the Opto-FIP data analysis. For nwb packaging, the `Software_TS` column should be eaxtracted from each csv and used.
+`SoftwareTS` :software timestamps. this should be used for the analysis of this modality as HARP is not used for any behavior and physiology.
+
+`ROI0` :average pixel values inside the ROI0
+
+`ROI1` :average pixel values inside the ROI1
+
+`ROI2` :average pixel values inside the ROI2
+
+`ROI3` :average pixel values inside the ROI3
+
+`ROI4_sensorfloor` :average pixel values inside the ROI4 correcponding CMOS background noise
+
+`HarpTS` :Corresponding Harp timestamp but this shouldn't be used.
+
+A HARP Device (behavior board) is only used to trigger behavior cameras. Given the fip acquision and optogenetic stimulations are temporally precisely controlled together by the Teeny microcontroller, we use software(OS) timestamps for the Opto-FIP data analysis. For nwb packaging, the `Software_TS` column should be eaxtracted from each csv and used.
+
+## Fiber/ROI mapping 
+Given only one out of the 4 patch-cables for the opto-stim FIP system is used for stimulation, this modality of the fip data is not sticking to the nubering rule — the more anterior, and then more left fibers get smaller number. It should be described in the session schema but in most recordings, Fiber1 (ROI1) is corresponding to stimulation site. This mapping will be better described in the schema2.0. 
 
 ## Stimulation pulse train description
 OptoStimulation is defined by the following five parameters and `modes` `o` (10Hz), `p` (20Hz), `q` (5Hz).


### PR DESCRIPTION
We agreed that standard is standard, not documentation. That said, given the OptoFIP will not be using HARP, this should be a standalone standard in parallel with other FIP instances.