### PR TITLE
Add optional sensor background information to FIP file format specification

### DIFF
--- a/docs/file_formats/fip.md
+++ b/docs/file_formats/fip.md
@@ -76,7 +76,7 @@ In some experiments, operators may choose to record background frames without an
 
 If the background files are not present, users can assume that no background frames were recorded during the session.
 
-If the background files are present the must contain at least one frame (i.e. row) in the corresponding `<color>_background.csv` file.
+If the background files are present they must contain at least one frame (i.e. row) in the corresponding `<color>_background.csv` file.
 
 If one background file is present, all background files must be present.
 


### PR DESCRIPTION
## Summary

This change is fully backwards compatible since tracking this information is optional.

## Motivation

While optional, this is something that warrants having a way to explicitly track in the specification. If it ends up being something that everyone MUST do we should also consider making it required in the future.

## Detailed Design

In short, we will add a few optional files that mirror the already existing structure for "real data". See the diff for further details.

## Relevant Issues
Closes #52 