### PR TITLE
fix: Try to get caution block to format correctly on documentation website

### DIFF
--- a/docs/file_formats/behavior_videos.md
+++ b/docs/file_formats/behavior_videos.md
@@ -95,14 +95,14 @@ necessary at the time of writing for gray pixel format inputs due to incorrect
 chroma initialization for p010le. Depending on your pixel format, and recent
 changes to ffmpeg, this may not be necessary.
 
-For the video should retain 10
-bit depth after gamma encoding (not always necessary), The offline encoder will also need
-to be changed,  For example, set the output arguments to:
+For the video to retain 10 bit depth for long-term storage, the offline encoder will also need to be changed. For example, set the output arguments to:
 ```
 -vf "colorspace=ispace=bt709:all=bt709:dither=none,scale=out_range=tv:sws_dither=none,format=yuv420p10le"
 -c:v libx264 -preset veryslow -crf 18 -pix_fmt yuv420p10le
 -metadata author="Allen Institute for Neural Dynamics" -movflags +faststart+write_colr
 ```
+
+However, acquiring at 10 bits, gamma encoding, and saving 8 bit-depth videos for long-term storage is sufficient for many applications.
 
 ### Application notes
 
@@ -114,19 +114,19 @@ Additional cameras could be supported but the user should provide the necessary 
 
 > [!CAUTION]
 > It is the user's responsibility to ensure that:
->
+> 
 > - The camera is correctly calibrated and that the settings are appropriate for the experiment.
->
+> 
 > - Unless there is a reason not to, the default logging pattern should always follow the following logic: (Stop trigger if needed) -> Start logging -> Start Camera -> Start Trigger -> Acquire data -> Stop Trigger -> Stop Logging. This guarantees that all relevant events are recorded.
->
+> 
 > - Trigger generation only starts AFTER the camera hardware has been initialized. This is to ensure that the camera is ready to receive the first trigger signal.
->
+> 
 > - For each trigger of the trigger source (e.g. Harp Behavior board) a corresponding camera exposure should occur. One example where this can be violated is if the set exposure is greater than the trigger frequency.
->
+> 
 > - In absence of dropped frames (defined as skips in the FrameNumber > 1) the metadata.csv file is expected to be aligned with the video file.
->
+> 
 > - (Optional) Start trigger and Stop trigger events should be available for QC.
->
+> 
 > - (Optional) The logs of all triggers (regardless of whether they are logged in the metadata.csv) should be saved for redundancy.
 
 #### Acquisition and Logging


### PR DESCRIPTION
Turns out the trailing spaces were required.