### PR TITLE
Adopt RFC2119 and refactor existing standards

### DIFF
--- a/docs/core/core-standards.md
+++ b/docs/core/core-standards.md
@@ -6,7 +6,7 @@ The goal of this document is NOT to be exhaustive and opinionated. Instead, it s
 
 ### Requirements Language
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this repository are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
 
 ### Filename conventions

--- a/docs/core/core-standards.md
+++ b/docs/core/core-standards.md
@@ -2,15 +2,20 @@
 
 ## Core Standards
 
-The goal of this document is NOT to be exhaustive and opinionated. Instead, it should include a minimal list of common patterns that can be easily referenced and re-used across all data formats standards guaranteeing a minimal level of consistency and quality.
+The goal of this document is NOT to be exhaustive and opinionated. Instead, it should include a minimal list of common patterns that can be easily referenced and reused across all data formats standards guaranteeing a minimal level of consistency and quality.
+
+### Requirements Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+
 
 ### Filename conventions
 
 In general, filename conventions will be defined by the specific data format standard. However, some general rules will be enforced:
 
-- Filenames must not contain spaces or special characters. [Use this as a reference for special characters](https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words).
-- "Underscore" `_` should be used instead of "-" or any other special character to separate words.
-- Filenames must always contain a file extension.
+- Filenames MUST not contain spaces or special characters. [Use this as a reference for special characters](https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words).
+- "Underscore" `_` MUST be used instead of "-" or any other special character to separate words.
+- Filenames SHOULD always contain a file extension.
 - **Any** file name can be suffixed with a `datetime`. This suffix will ALWAYS be the last suffix in the filename, in case multiple suffixes are used, and will follow the ISO 8601 format. Following Scientific Computing guidelines, if a `datetime` field is added we will adopt the [format `YYYY-MM-DDTHHMMSS` e.g. `2023-12-25T133015`]. The `datetime` will always be read as local-time zone. Should universal time (i.e. UTC) or time-zone information be necessary, users should look into the metadata asset potentially generated with the data.
 
   - As an example, if two files (`data_stream.bin`) are generated as part of two different acquisition [streams](https://aind-data-schema.readthedocs.io/en/latest/session.html):
@@ -35,9 +40,9 @@ In general, filename conventions will be defined by the specific data format sta
 
 ### Datetime
 
-All `datetime` used in data formats should follow the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. This standard is widely used and supported by most programming languages and libraries. In most cases, we expect `datetime` to be timezone aware, however if no suffix is added, `datetime` will be considered time-zone unaware and representing local time.
+All `datetime` used in data formats MUST follow the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. This standard is widely used and supported by most programming languages and libraries. In most cases, we expect `datetime` to be timezone aware, however if no suffix is added, `datetime` will be considered time-zone unaware and representing local time.
 
-The following formats are supported by the ISO 8601 standard and can be used:
+The following formats are supported by the ISO 8601 standard and MAY be used:
 
 ```plaintext
 YYYY-MM-DDTHHMMSS e.g. 2023-12-25T133015
@@ -70,9 +75,9 @@ The supported tabular formats are:
 
 #### Comma-separated values (CSV)
 
-CSV files will follow a subset of the [RFC 4180](https://tools.ietf.org/html/rfc4180) standard. The following rules will be enforced:
+CSV files MUST follow a subset of the [RFC 4180](https://tools.ietf.org/html/rfc4180) standard. The following rules will be enforced:
 
-- The first row will always be the header row.
-- The separator will always be a comma `,`.
-- The file will always be encoded in UTF-8.
-- The extension of the file will always be `.csv`.
+- The first row will ALWAYS be the header row.
+- The separator will ALWAYS be a comma `,`.
+- The file will ALWAYS be encoded in UTF-8.
+- The extension of the file will ALWAYS be `.csv`.

--- a/docs/file_formats/behavior_curriculum.md
+++ b/docs/file_formats/behavior_curriculum.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-0.1.0
+0.1.1
 
 ## Introduction
 
@@ -25,7 +25,7 @@ This standard prescribes a location, naming convention, and format for persistin
 
 ## Acquisition/Raw/Primary Data Format
 
-A file named `trainer_state.json` SHALL be stored inside the `behavior/` modality folder of the data asset. This file contains the serialized `TrainerState` at the time of session acquisition.
+A file named `trainer_state.json` SHALL be stored inside the `behavior/` modality folder of the data asset. This file MUST contain the serialized `TrainerState` at the time of session acquisition.
 
 ```plaintext
 📦<session_data_asset>
@@ -35,7 +35,7 @@ A file named `trainer_state.json` SHALL be stored inside the `behavior/` modalit
 ┗ ...
 ```
 
-It should be noted that this file, following the standard naming convention, can be appended with a `datetime` suffix if multiple curriculum states need to be stored for the same session (e.g. multiple behavior streams):
+It should be noted that this file, following the standard naming convention, MAY be appended with a `datetime` suffix if multiple curriculum states need to be stored for the same session (e.g. multiple behavior streams):
 
 ```plaintext
 📦<session_data_asset>
@@ -84,6 +84,6 @@ The information in the trainer state MUST NOT be serialized into any of the meta
 
 ### File Quality Assurances
 
-- If it exists, it must be able to be found using "trainer_state*.json" glob pattern in the `behavior/` modality folder.
+- If it exists, it MUST be able to be found using "trainer_state*.json" glob pattern in the `behavior/` modality folder.
 - The file MUST be valid JSON and parseable by `aind-behavior-curriculum`'s `TrainerState` model.
 - The file MUST be encoded in UTF-8.

--- a/docs/file_formats/behavior_videos.md
+++ b/docs/file_formats/behavior_videos.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-0.2.0
+0.2.1
 
 ## Introduction
 
@@ -10,11 +10,11 @@ This document describes the standards for acquiring video data from behavior exp
 
 ## Acquisition/Raw/Primary Data Format
 
-Following SciComp standards, video data from behavior experiments should be saved to the `behavior-videos` modality folder.
+Following SciComp standards, video data from behavior experiments MUST be saved to the `behavior-videos` modality folder.
 
-Inside this folder, each camera should have its own directory, named `<CameraName>`. Inside each camera folder, there should be two files: `video.<extension>` and `metadata.csv`. The `video.<extension>` file should contain the video data, and the `metadata.csv` file should contain the metadata for the video.
+Inside this folder, each camera MUST have its own directory, named `<CameraName>`. Inside each camera folder, there MUST be two files: `video.<extension>` and `metadata.csv`. The `video.<extension>` file MUST contain the video data, and the `metadata.csv` file MUST contain the metadata for the video.
 
-`<CameraName>` is expected to match the name defined in the rig metadata file (`rig.json`)
+`<CameraName>` SHOULD match the name defined in the rig metadata file (`rig.json`)
 
 The folder structure will thus be:
 
@@ -28,7 +28,7 @@ The folder structure will thus be:
 ┃ ┗ 📜video.mp4
 ```
 
-If multiple streams from the same camera are acquired in the same session, an optional `datetime` suffix can be added to the container's name:
+If multiple streams from the same camera are acquired in the same session, an optional `datetime` suffix MAY be added to the container's name:
 
 ```plaintext
 📦behavior-videos
@@ -49,14 +49,14 @@ The metadata file is expected to contain the following columns:
 - `CameraFrameTime` – Frame acquisition time given by the camera API or manually added by the user (e.g. using OS scheduler for webcams).
 
 
-As for the video, since the format will depend on the scientific question and software/hardware constrains, we will not enforce a specification. However, we strongly discourage the use of RAW, uncompressed data, and should the user not have a preference, we suggest the follow default:
+As for the video, since the format will depend on the scientific question and software/hardware constrains, we will not enforce a specification. However, we strongly discourage the use of RAW, uncompressed data, and should the user not have a preference, the following default SHOULD be used:
 
 Use a separate online encoder and offline encoder for use during acquisition, and long-term storage, respectively
 
 For the online encoder:
 
-- Acquire without any gamma correction
-- Acquire with the mkv format so that files are not corrupted if acquisition is
+- MUST acquire without any gamma correction
+- SHOULD acquire with the mkv format so that files are not corrupted if acquisition is
   abnormally terminated, i.e. the video files should be named like `video.mkv`
 - Use `ffmpeg` with the following encoding codec string for online encoding (optimized for compression quality and speed):
 
@@ -80,7 +80,7 @@ Note: this hasn't been tested as thoroughly.
 For higher bit depth (more than eight) recordings, change the output arguments of the online encoding to be as follows:
   - output arguments: `-vf "format=yuv420p10le,scale=out_range=full,setparams=range=full:colorspace=bt709:color_primaries=bt709:color_trc=linear" -c:v hevc_nvenc -pix_fmt p010le -color_range full -colorspace bt709 -color_trc linear -tune hq -preset p4 -rc vbr -cq 12 -b:v 0M -metadata author="Allen Institute for Neural Dynamics" -maxrate 700M -bufsize 350M -f matroska -write_crc32 0`
 
-The HEVC encoder must be used to support 10 bit depth, and the pixel format has
+The HEVC encoder may need to be used to support 10 bit depth, and the pixel format has
 been changed to `p010le` which is a yuv420-like 10 bit pixel format that is
 accepted by NVENC. We also recommend using `.mkv` videos at the rig, to reduce
 the risk of data loss.
@@ -95,7 +95,7 @@ necessary at the time of writing for gray pixel format inputs due to incorrect
 chroma initialization for p010le. Depending on your pixel format, and recent
 changes to ffmpeg, this may not be necessary.
 
-For the video to retain 10 bit depth for long-term storage, the offline encoder will also need to be changed. For example, set the output arguments to:
+For the video to retain 10 bit depth for long-term storage, the offline encoder MUST also be changed. For example, set the output arguments to:
 ```
 -vf "colorspace=ispace=bt709:all=bt709:dither=none,scale=out_range=tv:sws_dither=none,format=yuv420p10le"
 -c:v libx264 -preset veryslow -crf 18 -pix_fmt yuv420p10le
@@ -140,23 +140,23 @@ While we suggest using the aforementioned recipes, the user is free to use any s
 
 ### Relationship to aind-data-schema
 
-`<CameraName>` is expected to match the name defined in the rig metadata file (`rig.json`). Several fields in the metadata can be automatically extracted from this file format (e.g. start and stop of the stream, resolution of the video). However, the user should ensure that any data pertaining to the hardware configuration (e.g. camera model, exposure time, gain, camera position, etc...) is logged indepedently from this file format herein described.
+`<CameraName>` SHOULD match the name defined in the rig metadata file (`rig.json`). Several fields in the metadata can be automatically extracted from this file format (e.g. start and stop of the stream, resolution of the video). However, the user SHOULD ensure that any data pertaining to the hardware configuration (e.g. camera model, exposure time, gain, camera position, etc...) is logged independently from this file format herein described.
 
 ### File Quality Assurances
 
 The following features should be true if the data asset is to be considered valid:
 
-- The number of frames in the encoded video should match the number of recorded frames and the number of frames in the metadata.
+- The number of frames in the encoded video MUST match the number of recorded frames and the number of frames in the metadata.
 
 - Check if dropped frames occurred. This should be done in two ways:
 
-  - The difference between adjacent FrameNumber is always 1;
+  - The difference between adjacent FrameNumber is ALWAYS 1;
 
-  - The difference between adjacent Seconds and adjacent FrameTime should be very close (I would suggest a threshold of 0.5ms for now);
+  - The difference between adjacent Seconds and adjacent FrameTime SHOULD be very close (<0.5ms);
 
 > [!NOTE]
 > While dropped frames are not ideal, they do not necessarily invalidate the data. However, the user should be aware of the potential consequences and/or ways to correct the data asset.
 
-- If using a stable frame rate (this should be inferred from a rig configuration file), the average frame rate should match the theoretical frame rate;
+- If using a stable frame rate (this should be inferred from a rig configuration file), the average frame rate SHOULD match the theoretical frame rate;
 
-(optional) If the optional start and stop events are provided, the following temporal order should be asserted: `All(StartTrigger < Frames  < StopTrigger>)`
+(optional) If the optional start and stop events are provided, the following temporal order SHOULD be asserted: `All(StartTrigger < Frames  < StopTrigger>)`

--- a/docs/file_formats/harp.md
+++ b/docs/file_formats/harp.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-0.2.0
+0.2.1
 
 ## Introduction
 
@@ -23,7 +23,7 @@ Furthermore, each address, as per harp protocol spec, has potentially different 
 
 This analysis could be entirely eliminated if we knew that all messages in the binary file had the same format. For any Harp device, the payload stored in a specific register will have a fixed type and length. This means that to ensure our simplifying assumption it is enough to save each message from a specific register into a different file (aka de-multiplexing strategy).
 
-Thus, for each device, the container of all data will be a single directory with the extension `<>.harp`. This directory will contain the following files:
+Thus, for each device, the container of all data MUST be a single directory with the extension `<>.harp`. This directory SHALL contain the following files:
 
 ```plaintext
 📦<Device>.harp
@@ -37,13 +37,13 @@ Thus, for each device, the container of all data will be a single directory with
 
 where:
 
-- `<DeviceName>` will be derived from the `device.yml` metadata file that fully defines the device and can be found in the repository of each device ([e.g.](https://raw.githubusercontent.com/harp-tech/device.behavior/main/device.yml)). This file can be seen as the "ground truth" specification of the device. It is used to automatically generate documentation, interfaces and data ingestion tools.
-- `<Device>` should match the name of the device in the `rig.json` schema file;
+- `<DeviceName>` SHOULD be derived from the `device.yml` metadata file that fully defines the device and can be found in the repository of each device ([e.g.](https://raw.githubusercontent.com/harp-tech/device.behavior/main/device.yml)). This file can be seen as the "ground truth" specification of the device. It is used to automatically generate documentation, interfaces and data ingestion tools.
+- `<Device>` SHOULD match the name of the device in the `rig.json` schema file;
 - `<Reg>` is the register number that is logged in the binary file.
 
 #### On the `device.yml` file
 
-Including the `device.yml` file that corresponds to the device interface used to log the device's data is required. This file affords the use of diverse tooling offered by the ecosystem, in particular [device-type-aware data ingestion tools](https://github.com/harp-tech/harp-python). Note that while the `device.yml` file specifies the targeted hardware, firmware, and core versions, it does not guarantee that the device from which data was acquired is running those versions. This metadata should instead be queried directly from the corresponding device's registers([see protocol core registers](https://harp-tech.org/protocol/Device.html#table---list-of-available-common-registers))
+Including the `device.yml` file that corresponds to the device interface used to log the device's data is REQUIRED. This file affords the use of diverse tooling offered by the ecosystem, in particular [device-type-aware data ingestion tools](https://github.com/harp-tech/harp-python). Note that while the `device.yml` file specifies the targeted hardware, firmware, and core versions, it does not guarantee that the device from which data was acquired is running those versions. This metadata MAY instead be queried directly from the corresponding device's registers([see protocol core registers](https://harp-tech.org/protocol/Device.html#table---list-of-available-common-registers))
 
 - An example of an yml file can be found here: [device.yml](https://raw.githubusercontent.com/harp-tech/device.behavior/main/device.yml)
 - And the schema for the yml file can be found here: [device.yml schema](https://raw.githubusercontent.com/harp-tech/protocol/refs/heads/main/schema/device.json)
@@ -52,7 +52,7 @@ Including the `device.yml` file that corresponds to the device interface used to
 
 A critical aspect of using the Harp protocol is that for each `Write` message received by the device from the PC host, the client will echo back a Write message timestamped by the embedded device. This assumes that all messages issued by the host are received by the device and not lost in transmission. However, this is not guaranteed. In case of a lost message, the host will not receive the echo back and cannot confirm that the message was received by the device.
 
-To perform post-hoc quality control, we recommend also logging `Commands`. Since `Commands` are also HarpMessage types, they can be logged in the same format as data from devices. We also recommend appending a software timestamp to each `Command` message to facilitate pairing requests with responses post-hoc.
+To perform post-hoc quality control, we RECOMMEND also logging `Commands`. Since `Commands` are also HarpMessage types, they can be logged in the same format as data from devices. We also RECOMMEND appending a software timestamp to each `Command` message to facilitate pairing requests with responses post-hoc.
 
 
 ### Application notes
@@ -75,13 +75,13 @@ Instructions on how to log data from a Harp device using Bonsai can be found in 
 A "syntactic sugar" operator for logging device data with a corresponding device.yml file is also available in via the [AllenNeuralDynamics.HarpUtils](https://allenneuraldynamics.github.io/Bonsai.AllenNeuralDynamics/articles/core-logging.html#with-metadata) package.
 
 > [!IMPORTANT]
-> In your experiments, always validate that your logging routine has fully initialized before requesting a reading dump from the device. Failure to do so may result in missing data.
+> In your experiments, ALWAYS validate that your logging routine has fully initialized before requesting a reading dump from the device. Failure to do so may result in missing data.
 
 > [!NOTE]
 > In the future we will update these recipes to also provide AIND specific examples.
 
 
-It is critical that the messages logged from the device are sufficient to reconstruct its state history. For that to be true, we need to know the initial state of all registers. This can be asked via a special register in the protocol core: [`OperationControl`](https://harp-tech.org/protocol/Device.html#r_operation_ctrl-u16--operation-mode-configuration). This register has a single bit that, when set, will trigger the device to send a dump all the values of all its registers.
+It is critical that the messages logged from the device are sufficient to reconstruct its state history. For that to be true, we SHOULD know the initial state of all registers. This can be asked via a special register in the protocol core: [`OperationControl`](https://harp-tech.org/protocol/Device.html#r_operation_ctrl-u16--operation-mode-configuration). This register has a single bit that, when set, will trigger the device to send a dump all the values of all its registers.
 
 - To the previous [logging example](https://harp-tech.org/articles/logging.html#groupbyregister), in a different branch:
 - Add a `Timer` operator with its `DueTime` property set to 2 seconds. This will mimic the delayed start of an experiment.
@@ -148,8 +148,8 @@ Most fields tracked in `rig.json` can be easily extracted from the device's read
 
 By virtue of implementing the Harp communication and synchronization protocol the following should be true:
 
-1) Each data set should, at most, have a device as a source of the synchronized clock.
-2) All messages from the device to the computer host should be logged. Once a message is successfully parsed, no more processing and/or filtering of the data stream will be done prior to logging.
-3) All data from a single device will include the initial state of all registers. This can be achieved by setting the `DumpRegisters` bit in the `OperationControl` register. Given that this is true, inside the container folder, one file per register of the device is expected to be found with a minimum of one message in each file.
-4) If Commands are logged, for each message sent to the device, a corresponding message should exist in the logged data from the harp device. The type of the message in the Command will match the type of the reply from the device.
+1) Each data set SHOULD, at most, have a device as a source of the synchronized clock.
+2) All messages from the device to the computer host SHOULD be logged. Once a message is successfully parsed, no more processing and/or filtering of the data stream will be done prior to logging.
+3) All data from a single device SHOULD include the initial state of all registers. This can be achieved by setting the `DumpRegisters` bit in the `OperationControl` register. Given that this is true, inside the container folder, one file per register of the device is expected to be found with a minimum of one message in each file.
+4) If Commands are logged, for each message sent to the device, a corresponding message SHOULD exist in the logged data from the harp device. The type of the message in the Command will match the type of the reply from the device.
 5) If multiple devices are used, all data is assumed to be synchronized at acquisition time.


### PR DESCRIPTION
This PR explicitly adds RFC2119 as the language standard for requirements definition. I have updated some of the standards I have been maintaining but, if accepted, I think other files deserve the same treatment.

Closes #55